### PR TITLE
Fix warning about STRICT_ALL_TABLES in mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN ulimit -c 10000
 # Clean packages
 RUN apt-get clean
 
+VOLUME /opt/phabricator/conf/local
 EXPOSE 3306 80 22
 
 CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
Phabricator gives the following warning:

```
On your MySQL instance, the global sql_mode is not set to STRICT_ALL_TABLES. It is strongly encouraged that you enable this mode when running Phabricator.

By default MySQL will silently ignore some types of errors, which can cause data loss and raise security concerns. Enabling strict mode makes MySQL raise an explicit error instead, and prevents this entire class of problems from doing any damage.

You can find more information about this mode (and how to configure it) in the MySQL manual. Usually, it is sufficient to add this to your my.cnf file (in the [mysqld] section) and then restart mysqld:

sql_mode=STRICT_ALL_TABLES

(Note that if you run other applications against the same database, they may not work in strict mode. Be careful about enabling it in these cases.)
```

Adding this should fix the problem.

```
RUN sed -i 's/\[mysqld\]/[mysqld]\nsql_mode=STRICT_ALL_TABLES/' /etc/mysql/my.cnf
```

Confirmed that this fix works.

This also exposes a volume for local configuration files

```
The user can now run docker run -P -v /data/phabricator_conf:/opt/phabricator/conf/local to be able to save these changes

For example /opt/phabricator/bin/config set phabricator.base-uri http://phabricator.local.com/ should now work
```
