### PR TITLE
Make docker-phabricator email work with postfix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN mkdir -p '/var/repo/'
 
 RUN ulimit -c 10000
 
+RUN apt-get remove -y exim4
+RUN apt-get install -y postfix
+
 # Clean packages
 RUN apt-get clean
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,6 +4,9 @@ nodaemon=true
 [program:sshd]
 command=/usr/sbin/sshd -D
 
+[program:postfix]
+command=service postfix start
+
 [program:apache2]
 command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
 


### PR DESCRIPTION
Hey, tried to make the image work with sendmail/exim4 but it complained quite badly. Ended up using postfix and worked.

Would fix #17 :)