### PR TITLE
Remove job 'sshd' from supervisord

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,9 +1,6 @@
 [supervisord]
 nodaemon=true
 
-[program:sshd]
-command=/usr/sbin/sshd -D
-
 [program:apache2]
 command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
 


### PR DESCRIPTION
Removed job 'sshd' from supervisord since sshd is no longer installed.