### PR TITLE
Add support for arbitary Mysql server/user/pass and arbitary local.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@
 FROM    debian:jessie
 MAINTAINER  Yvonnick Esnault <yvonnick@esnau.lt>
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
 
 # TODO: review this dependency list
 RUN     apt-get update && apt-get install -y \
@@ -32,7 +31,7 @@ RUN     apt-get update && apt-get install -y \
             tar \
         && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# For some reason phabricator doesn't have tagged releases. To support 
+# For some reason phabricator doesn't have tagged releases. To support
 # repeatable builds use the latest SHA
 ADD     download.sh /opt/download.sh
 WORKDIR /opt
@@ -53,5 +52,6 @@ ADD     local.json /opt/phabricator/conf/local/local.json
 RUN     sed -i -e 's/post_max_size = 8M/post_max_size = 32M/' /etc/php5/apache2/php.ini
 
 EXPOSE  80
-CMD     bash -c "source /etc/apache2/envvars; /usr/sbin/apache2 -DFOREGROUND"
-
+ADD     entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD     ["start-server"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if [ -z "${LOCAL_JSON}" ]; then
+  [ -z "${MYSQL_HOST}" ] && export MYSQL_HOST="database"
+  [ -z "${MYSQL_USER}" ] && export MYSQL_USER="admin"
+  [ -z "${MYSQL_PASS}" ] && export MYSQL_PASS="admin"
+
+  # Patching the settings file.
+  sed -e "s/{{MYSQL_HOST}}/${MYSQL_HOST}/g" \
+    -e "s/{{MYSQL_USER}}/${MYSQL_USER}/g" \
+    -e "s/{{MYSQL_PASS}}/${MYSQL_PASS}/g" \
+    -i /opt/phabricator/conf/local/local.json
+else
+  echo "${LOCAL_JSON}" > /opt/phabricator/conf/local/local.json
+fi
+
+if [ "${1}" = "start-server" ]; then
+  exec bash -c "source /etc/apache2/envvars; /usr/sbin/apache2 -DFOREGROUND"
+else
+  exec $@
+fi

--- a/local.json
+++ b/local.json
@@ -1,7 +1,7 @@
 {
       "storage.default-namespace": "default",
-      "mysql.host": "database",
-      "mysql.pass": "admin",
-      "mysql.user": "admin",
+      "mysql.host": "{{MYSQL_HOST}}",
+      "mysql.user": "{{MYSQL_USER}}",
+      "mysql.pass": "{{MYSQL_PASS}}",
       "pygments.enabled": true
 }


### PR DESCRIPTION
This PR makes the config more in the environment variable to adhere more with [12factor/config](http://12factor.net/config). This makes it easier to deploy on [Deis](http://deis.io)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/yesnault/docker-phabricator/29)
<!-- Reviewable:end -->
