### PR TITLE
Resolve setup issue "OPcache Not Configured for Production".

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN     mkdir -p /opt/phabricator/conf/local /var/repo
 ADD     local.json /opt/phabricator/conf/local/local.json
 RUN     sed -e 's/post_max_size = 8M/post_max_size = 32M/' \
           -e 's/upload_max_filesize = 2M/upload_max_filesize = 32M/' \
+          -e 's/;opcache.validate_timestamps=1/opcache.validate_timestamps=0/' \
           -i /etc/php5/apache2/php.ini
 RUN     ln -s /usr/lib/git-core/git-http-backend /opt/phabricator/support/bin
 RUN     /opt/phabricator/bin/config set phd.user "root"


### PR DESCRIPTION
Set opcache.validate_timestamps to false In production environment,