### PR TITLE
Add apt-get clean before apt-get udpate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER  Yvonnick Esnault <yvonnick@esnau.lt>
 ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
 
 # TODO: review this dependency list
-RUN     apt-get update && apt-get install -y \
+RUN     apt-get clean && apt-get update && apt-get install -y \
 	        git \
             apache2 \
             curl \


### PR DESCRIPTION
Ran into some errors with the apt cache failing when a package was updated.