### PR TITLE
OSX specific fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,28 @@ docker run --name databasePhabricator yesnault/docker-phabricator-mysql
 
 Run phabricator :
 ```
-docker run -p 8081:80 --link databasePhabricator:database yesnault/docker-phabricator 
+docker run -p 8080:80 --link databasePhabricator:database yesnault/docker-phabricator 
 ```
-Go to http://localhost:8081
+Go to http://127.0.0.1:8080
 
 Running on OSX
 -------
 
+Docker for Mac
+From a terminal, execute:
+
+```
+docker-compose up
+```
+
+Go to http://127.0.0.1:8080
+
+
+Boot2 Docker
+
 Requires
 
-  * boot2docker
+  * Docker
 
   * docker
 
@@ -41,5 +53,5 @@ boot2docker ip
 Then open up a browser and navigate to
 
 ```
-http://{boot2docker ip}:8081
+http://{boot2docker ip}:8080
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Go to http://127.0.0.1:8080
 Running on OSX
 -------
 
-Docker for Mac
+
+###### Docker for Mac
 From a terminal, execute:
 
 ```
@@ -30,7 +31,7 @@ docker-compose up
 Go to http://127.0.0.1:8080
 
 
-Boot2 Docker
+###### Boot2 Docker
 
 Requires
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,13 @@
 #  - /var/repo - code repos
 #
 #
-phabricator:
-    build: .
-    links: ['database']
-    ports: ['8081:80']
-
 
 database:
     build: database/
+    hostname: database
+
+phabricator:
+    build: .
+    links: ['database']
+    ports: ['8080:80']
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+until mysql --protocol=socket -uroot -pAgil1234 -e 'select 1' > /dev/null; do echo "Waiting for mysql..."; sleep 2; done
 
 if [ -z "${LOCAL_JSON}" ]; then
   [ -z "${MYSQL_HOST}" ] && export MYSQL_HOST="database"
@@ -15,6 +16,7 @@ else
 fi
 
 if [ "${1}" = "start-server" ]; then
+
   exec bash -c "/opt/phabricator/bin/storage upgrade --force; /opt/phabricator/bin/phd start; source /etc/apache2/envvars; /usr/sbin/apache2 -DFOREGROUND"
 else
   exec $@


### PR DESCRIPTION
- Wait for MySQL container before setting up Phabricator
- Phabricator prefers 127.0.0.1 to localhost
- Added steps for 'Docker for Mac'
- On OSX 8081 is taken by sunproxyadmin and not easy to claim back